### PR TITLE
수강신청 Api 추가 및 테스트 코드 수정

### DIFF
--- a/src/main/kotlin/com/example/checkcheck/lecture/controller/LectureController.kt
+++ b/src/main/kotlin/com/example/checkcheck/lecture/controller/LectureController.kt
@@ -54,7 +54,7 @@ class LectureController(
      * 사용자 id를 통해 강의 조회 Api
      */
     @Operation(summary = "사용자별 강의 조회", description = "사용자별 강의 조회 Api 입니다")
-    @GetMapping("/userlecture/{memberId}")
+    @GetMapping("/userLecture/{memberId}")
     fun getLecturesByUserId(@PathVariable memberId: Long):
             ResponseEntity<BaseResponse<List<LectureResponseDto>>> {
         val result = lectureService.getLecturesByUserId(memberId)
@@ -86,7 +86,7 @@ class LectureController(
      * 강의 시작시간 변경 Api
      */
     @Operation(summary = "강의 시작시간 변경", description = "강의 시작시간 변경 Api 입니다")
-    @PutMapping("/startat/{id}")
+    @PutMapping("/lectureStartAt/{id}")
     private fun putLectureStartAt(@Valid @RequestBody lectureScheduleRequestDto: LectureScheduleRequestDto, @PathVariable id: Long):
             ResponseEntity<BaseResponse<LectureScheduleRequestDto>> {
         val result = lectureService.putLectureStartAt(lectureScheduleRequestDto, id)
@@ -97,10 +97,54 @@ class LectureController(
      * 강의 종료시간 변경 Api
      */
     @Operation(summary = "강의 종료시간 변경", description = "강의 종료시간 변경 Api 입니다")
-    @PutMapping("/endat/{id}")
+    @PutMapping("/lectureEndAt/{id}")
     private fun putLectureEndAt(@Valid @RequestBody lectureScheduleRequestDto: LectureScheduleRequestDto, @PathVariable id: Long):
             ResponseEntity<BaseResponse<LectureScheduleRequestDto>> {
         val result = lectureService.putLectureEndAt(lectureScheduleRequestDto, id)
+        return ResponseEntity.status(HttpStatus.OK).body(BaseResponse(data = result))
+    }
+
+    /**
+     *  강의 시작기간 변경 Api
+     */
+    @Operation(summary = "강의 시작기간 변경", description = "강의 시작기간 변경 Api 입니다")
+    @PutMapping("/lectureStartDate/{id}")
+    private fun putLectureStartDate(@Valid @RequestBody lectureScheduleRequestDto: LectureScheduleRequestDto, @PathVariable id: Long):
+            ResponseEntity<BaseResponse<LectureScheduleRequestDto>> {
+        val result = lectureService.putLectureStartDate(lectureScheduleRequestDto, id)
+        return ResponseEntity.status(HttpStatus.OK).body(BaseResponse(data = result))
+    }
+
+    /**
+     * 강의 종료기간 변경 Api
+     */
+    @Operation(summary = "강의 종료기간 변경", description = "강의 종료기간 변경 Api 입니다")
+    @PutMapping("/lectureEndDate/{id}")
+    private fun putLectureEndDate(@Valid @RequestBody lectureScheduleRequestDto: LectureScheduleRequestDto, @PathVariable id: Long):
+            ResponseEntity<BaseResponse<LectureScheduleRequestDto>> {
+        val result = lectureService.putLectureEndDate(lectureScheduleRequestDto, id)
+        return ResponseEntity.status(HttpStatus.OK).body(BaseResponse(data = result))
+    }
+
+    /**
+     * 강의실 변경 Api
+     */
+    @Operation(summary = "강의실 변경", description = "강의실 변경 Api 입니다")
+    @PutMapping("lecturePlace/{id}")
+    private fun putLecturePlace(@Valid @RequestBody lectureScheduleRequestDto: LectureScheduleRequestDto, @PathVariable id: Long):
+            ResponseEntity<BaseResponse<LectureScheduleRequestDto>> {
+        val result = lectureService.putLecturePlace(lectureScheduleRequestDto, id)
+        return ResponseEntity.status(HttpStatus.OK).body(BaseResponse(data = result))
+    }
+
+    /**
+     * 강의 정보 변경 Api
+     */
+    @Operation(summary = "강의 정보 변경", description = "강의 정보 변경 Api 입니다")
+    @PutMapping("/lectureInfo/{id}")
+    private fun putLectureInfo(@Valid @RequestBody lectureScheduleRequestDto: LectureScheduleRequestDto, @PathVariable id: Long):
+            ResponseEntity<BaseResponse<LectureScheduleRequestDto>> {
+        val result = lectureService.putLectureInfo(lectureScheduleRequestDto, id)
         return ResponseEntity.status(HttpStatus.OK).body(BaseResponse(data = result))
     }
 }

--- a/src/main/kotlin/com/example/checkcheck/lecture/controller/LectureController.kt
+++ b/src/main/kotlin/com/example/checkcheck/lecture/controller/LectureController.kt
@@ -152,7 +152,7 @@ class LectureController(
     /**
      * 수강신청 시작 변경 Api
      */
-    @Operation(summary = "수강신청 시작 변경", description = "수강신청 시작 변경 Api 입니다")
+    @Operation(summary = "수강신청 시작 일정 변경", description = "수강신청 시작 변경 Api 입니다")
     @PutMapping("/periodStartDateTime/{id}")
     private fun putRegisterStartDateTime(@Valid @RequestBody registerPeriodRequestDto: RegisterPeriodRequestDto, @PathVariable id: Long):
             ResponseEntity<BaseResponse<RegisterPeriodRequestDto>> {
@@ -163,7 +163,7 @@ class LectureController(
     /**
      * 수강신청 종료 변경 Api
      */
-    @Operation(summary = "수강신청 종료 변경", description = "수강신청 시작 변경 Api 입니다")
+    @Operation(summary = "수강신청 종료 일정 변경", description = "수강신청 시작 변경 Api 입니다")
     @PutMapping("/periodEndDateTime/{id}")
     private fun putRegisterEndDateTime(@Valid @RequestBody registerPeriodRequestDto: RegisterPeriodRequestDto, @PathVariable id: Long):
             ResponseEntity<BaseResponse<RegisterPeriodRequestDto>> {

--- a/src/main/kotlin/com/example/checkcheck/lecture/controller/LectureController.kt
+++ b/src/main/kotlin/com/example/checkcheck/lecture/controller/LectureController.kt
@@ -147,4 +147,9 @@ class LectureController(
         val result = lectureService.putLectureInfo(lectureScheduleRequestDto, id)
         return ResponseEntity.status(HttpStatus.OK).body(BaseResponse(data = result))
     }
+
+//    /**
+//     * 수강신청 시작시간 변경 Api
+//     */
+//    @Operation(summary = "수강신청 시작시간 변경", description = "수강신청 시작시간 변경 Api 입니다")
 }

--- a/src/main/kotlin/com/example/checkcheck/lecture/controller/LectureController.kt
+++ b/src/main/kotlin/com/example/checkcheck/lecture/controller/LectureController.kt
@@ -5,6 +5,7 @@ import com.example.checkcheck.common.dtos.CustomUser
 import com.example.checkcheck.lecture.dto.LectureRequestDto
 import com.example.checkcheck.lecture.dto.LectureResponseDto
 import com.example.checkcheck.lecture.dto.LectureScheduleRequestDto
+import com.example.checkcheck.lecture.dto.RegisterPeriodRequestDto
 import com.example.checkcheck.lecture.service.LectureService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -148,8 +149,25 @@ class LectureController(
         return ResponseEntity.status(HttpStatus.OK).body(BaseResponse(data = result))
     }
 
-//    /**
-//     * 수강신청 시작시간 변경 Api
-//     */
-//    @Operation(summary = "수강신청 시작시간 변경", description = "수강신청 시작시간 변경 Api 입니다")
+    /**
+     * 수강신청 시작 변경 Api
+     */
+    @Operation(summary = "수강신청 시작 변경", description = "수강신청 시작 변경 Api 입니다")
+    @PutMapping("/periodStartDateTime/{id}")
+    private fun putRegisterStartDateTime(@Valid @RequestBody registerPeriodRequestDto: RegisterPeriodRequestDto, @PathVariable id: Long):
+            ResponseEntity<BaseResponse<RegisterPeriodRequestDto>> {
+        val result = lectureService.putRegisterStartDateTime(registerPeriodRequestDto, id)
+        return ResponseEntity.status(HttpStatus.OK).body(BaseResponse(data = result))
+    }
+
+    /**
+     * 수강신청 종료 변경 Api
+     */
+    @Operation(summary = "수강신청 종료 변경", description = "수강신청 시작 변경 Api 입니다")
+    @PutMapping("/periodEndDateTime/{id}")
+    private fun putRegisterEndDateTime(@Valid @RequestBody registerPeriodRequestDto: RegisterPeriodRequestDto, @PathVariable id: Long):
+            ResponseEntity<BaseResponse<RegisterPeriodRequestDto>> {
+        val result = lectureService.putRegisterEndDateTime(registerPeriodRequestDto, id)
+        return ResponseEntity.status(HttpStatus.OK).body(BaseResponse(data = result))
+    }
 }

--- a/src/main/kotlin/com/example/checkcheck/lecture/dto/LectureDtos.kt
+++ b/src/main/kotlin/com/example/checkcheck/lecture/dto/LectureDtos.kt
@@ -54,7 +54,7 @@ data class LectureRequestDto(
 
     @field:NotBlank(message = "수강신청 시작 일시를 입력해주세요.")
     @field:Pattern(
-        regexp = "^([0-9]{2})-([0-9]{2})-([0-9]{2}) ([0-9]{2}):([0-9]{2})$",
+        regexp = "^([0-9]{2})-([0-9]{2})-([0-9]{2}) ([01]\\d|2[0-3]):([0-5]\\d)\$",
         message = "형식을 확인해주세요! yy-MM-dd HH:mm"
     )
     @JsonProperty("registerStartDateTime")
@@ -62,7 +62,7 @@ data class LectureRequestDto(
 
     @field:NotBlank(message = "수강신청 종료 일시를 입력해주세요.")
     @field:Pattern(
-        regexp = "^([0-9]{2})-([0-9]{2})-([0-9]{2}) ([0-9]{2}):([0-9]{2})$",
+        regexp = "^([0-9]{2})-([0-9]{2})-([0-9]{2}) ([01]\\d|2[0-3]):([0-5]\\d)\$",
         message = "형식을 확인해주세요! yy-MM-dd HH:mm"
     )
     @JsonProperty("registerEndDateTime")

--- a/src/main/kotlin/com/example/checkcheck/lecture/dto/LectureDtos.kt
+++ b/src/main/kotlin/com/example/checkcheck/lecture/dto/LectureDtos.kt
@@ -52,37 +52,21 @@ data class LectureRequestDto(
     @JsonProperty("lecturePlace")
     private var _lecturePlace: String?,
 
-    @field:NotBlank(message = "수강신청 시작일을 입력해주세요.")
+    @field:NotBlank(message = "수강신청 시작 일시를 입력해주세요.")
     @field:Pattern(
-        regexp = "^([0-9]{2})-([0-9]{2})-([0-9]{2})$",
-        message = "기간 형식을 확인해주세요! yy-MM-dd"
+        regexp = "^([0-9]{2})-([0-9]{2})-([0-9]{2}) ([0-9]{2}):([0-9]{2})$",
+        message = "형식을 확인해주세요! yy-MM-dd HH:mm"
     )
-    @JsonProperty("registerStartDate")
-    private var _registerStartDate: String?,
+    @JsonProperty("registerStartDateTime")
+    private var _registerStartDateTime: String,
 
-    @field:NotBlank(message = "수강신청 종료일을 입력해주세요.")
+    @field:NotBlank(message = "수강신청 종료 일시를 입력해주세요.")
     @field:Pattern(
-        regexp = "^([0-9]{2})-([0-9]{2})-([0-9]{2})$",
-        message = "기간 형식을 확인해주세요! yy-MM-dd"
+        regexp = "^([0-9]{2})-([0-9]{2})-([0-9]{2}) ([0-9]{2}):([0-9]{2})$",
+        message = "형식을 확인해주세요! yy-MM-dd HH:mm"
     )
-    @JsonProperty("registerEndDate")
-    private var _registerEndDate: String?,
-
-    @field:NotBlank(message = "수강신청 시작시간을 입력해주세요.")
-    @field:Pattern(
-        regexp = "^([01]\\d|2[0-3]):([0-5]\\d)$",
-        message = "시간 형식을 확인해주세요! HH:mm"
-    )
-    @JsonProperty("registerStartAt")
-    private var _registerStartAt: String?,
-
-    @field:NotBlank(message = "수강신청 종료시간을 입력해주세요.")
-    @field:Pattern(
-        regexp = "^([01]\\d|2[0-3]):([0-5]\\d)$",
-        message = "시간 형식을 확인해주세요! HH:mm"
-    )
-    @JsonProperty("registerEndAt")
-    private var _registerEndAt: String?,
+    @JsonProperty("registerEndDateTime")
+    private var _registerEndDateTime: String,
 
     @field:Size(max = 300, message = "강의 정보는 최대 300글자 이내로 작성해 주세요.")
     @JsonProperty("lectureInfo")
@@ -109,17 +93,11 @@ data class LectureRequestDto(
     val lecturePlace: String
         get() = _lecturePlace!!
 
-    val registerStartDate: String
-        get() = _registerStartDate!!
+    val registerStartDateTime: String
+        get() = _registerStartDateTime
 
-    val registerEndDate: String
-        get() = _registerEndDate!!
-
-    val registerStartAt: String
-        get() = _registerStartAt!!
-
-    val registerEndAt: String
-        get() = _registerEndAt!!
+    val registerEndDateTime: String
+        get() = _registerEndDateTime
 
     val lectureInfo: String?
         get() = _lectureInfo
@@ -133,10 +111,8 @@ data class LectureResponseDto(
 )
 
 data class RegisterPeriodDto(
-    var registerStartDate: String,
-    var registerEndDate: String,
-    var registerStartAt: String,
-    var registerEndAt: String
+    var registerStartDateTime: String,
+    var registerEndDateTime: String,
 )
 
 data class LectureScheduleDto(

--- a/src/main/kotlin/com/example/checkcheck/lecture/dto/LectureDtos.kt
+++ b/src/main/kotlin/com/example/checkcheck/lecture/dto/LectureDtos.kt
@@ -52,7 +52,7 @@ data class LectureRequestDto(
     @JsonProperty("lecturePlace")
     private var _lecturePlace: String?,
 
-    @field:NotBlank(message = "수강신청 시작 일시를 입력해주세요.")
+    @field:NotBlank(message = "수강신청 시작 일정를 입력해주세요.")
     @field:Pattern(
         regexp = "^([0-9]{2})-([0-9]{2})-([0-9]{2}) ([01]\\d|2[0-3]):([0-5]\\d)\$",
         message = "형식을 확인해주세요! yy-MM-dd HH:mm"
@@ -60,7 +60,7 @@ data class LectureRequestDto(
     @JsonProperty("registerStartDateTime")
     private var _registerStartDateTime: String,
 
-    @field:NotBlank(message = "수강신청 종료 일시를 입력해주세요.")
+    @field:NotBlank(message = "수강신청 종료 일정를 입력해주세요.")
     @field:Pattern(
         regexp = "^([0-9]{2})-([0-9]{2})-([0-9]{2}) ([01]\\d|2[0-3]):([0-5]\\d)\$",
         message = "형식을 확인해주세요! yy-MM-dd HH:mm"

--- a/src/main/kotlin/com/example/checkcheck/lecture/dto/LectureDtos.kt
+++ b/src/main/kotlin/com/example/checkcheck/lecture/dto/LectureDtos.kt
@@ -54,7 +54,7 @@ data class LectureRequestDto(
 
     @field:NotBlank(message = "수강신청 시작 일정를 입력해주세요.")
     @field:Pattern(
-        regexp = "^([0-9]{2})-([0-9]{2})-([0-9]{2}) ([01]\\d|2[0-3]):([0-5]\\d)\$",
+        regexp = "^([0-9]{2})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]) ([01]\\d|2[0-3]):([0-5]\\d)\$",
         message = "형식을 확인해주세요! yy-MM-dd HH:mm"
     )
     @JsonProperty("registerStartDateTime")
@@ -62,7 +62,7 @@ data class LectureRequestDto(
 
     @field:NotBlank(message = "수강신청 종료 일정를 입력해주세요.")
     @field:Pattern(
-        regexp = "^([0-9]{2})-([0-9]{2})-([0-9]{2}) ([01]\\d|2[0-3]):([0-5]\\d)\$",
+        regexp = "^([0-9]{2})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]) ([01]\\d|2[0-3]):([0-5]\\d)\$",
         message = "형식을 확인해주세요! yy-MM-dd HH:mm"
     )
     @JsonProperty("registerEndDateTime")

--- a/src/main/kotlin/com/example/checkcheck/lecture/dto/RegisterPeriodDtos.kt
+++ b/src/main/kotlin/com/example/checkcheck/lecture/dto/RegisterPeriodDtos.kt
@@ -9,17 +9,17 @@ import java.time.format.DateTimeFormatter
 data class RegisterPeriodRequestDto(
     val id: Long? = null,
 
-    @field:NotBlank(message = "수강신청 시작 일시를 입력해주세요.")
+    @field:NotBlank(message = "수강신청 시작 일정를 입력해주세요.")
     @field:Pattern(
-        regexp = "^([0-9]{2})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]) ([01]\\d|2[0-3]):([0-5]\\d)\$",
+        regexp = "^([0-9]{2})-([0-9]{2})-([0-9]{2}) ([01]\\d|2[0-3]):([0-5]\\d)\$",
         message = "형식을 확인해주세요! yy-MM-dd HH:mm"
     )
     @JsonProperty("registerStartDateTime")
     val registerStartDateTime: String,
 
-    @field:NotBlank(message = "수강신청 종료 일시를 입력해주세요.")
+    @field:NotBlank(message = "수강신청 종료 일정를 입력해주세요.")
     @field:Pattern(
-        regexp = "^([0-9]{2})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]) ([01]\\d|2[0-3]):([0-5]\\d)\$",
+        regexp = "^([0-9]{2})-([0-9]{2})-([0-9]{2}) ([01]\\d|2[0-3]):([0-5]\\d)\$",
         message = "형식을 확인해주세요! yy-MM-dd HH:mm"
     )
     @JsonProperty("registerEndDateTime")

--- a/src/main/kotlin/com/example/checkcheck/lecture/dto/RegisterPeriodDtos.kt
+++ b/src/main/kotlin/com/example/checkcheck/lecture/dto/RegisterPeriodDtos.kt
@@ -11,7 +11,7 @@ data class RegisterPeriodRequestDto(
 
     @field:NotBlank(message = "수강신청 시작 일시를 입력해주세요.")
     @field:Pattern(
-        regexp = "^([0-9]{2})-([0-9]{2})-([0-9]{2}) ([0-9]{2}):([0-9]{2})$",
+        regexp = "^([0-9]{2})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]) ([01]\\d|2[0-3]):([0-5]\\d)\$",
         message = "형식을 확인해주세요! yy-MM-dd HH:mm"
     )
     @JsonProperty("registerStartDateTime")
@@ -19,7 +19,7 @@ data class RegisterPeriodRequestDto(
 
     @field:NotBlank(message = "수강신청 종료 일시를 입력해주세요.")
     @field:Pattern(
-        regexp = "^([0-9]{2})-([0-9]{2})-([0-9]{2}) ([0-9]{2}):([0-9]{2})$",
+        regexp = "^([0-9]{2})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]) ([01]\\d|2[0-3]):([0-5]\\d)\$",
         message = "형식을 확인해주세요! yy-MM-dd HH:mm"
     )
     @JsonProperty("registerEndDateTime")

--- a/src/main/kotlin/com/example/checkcheck/lecture/dto/RegisterPeriodDtos.kt
+++ b/src/main/kotlin/com/example/checkcheck/lecture/dto/RegisterPeriodDtos.kt
@@ -42,16 +42,16 @@ data class RegisterPeriodRequestDto(
     @JsonProperty("registerEndAt")
     private var registerEndAt: String?
 ) {
-    val startDate: LocalDate
+    val registerStartLocalDate: LocalDate
         get() = registerStartDate!!.toLocalDate()
 
-    val endDate: LocalDate
+    val registerEndLocalDate: LocalDate
         get() = registerEndDate!!.toLocalDate()
 
-    val startAt: LocalTime
+    val registerStartLocalAt: LocalTime
         get() = registerStartAt!!.toLocalTime()
 
-    val endAt: LocalTime
+    val registerEndLocalEndAt: LocalTime
         get() = registerEndAt!!.toLocalTime()
 
     private fun String.toLocalDate(): LocalDate =

--- a/src/main/kotlin/com/example/checkcheck/lecture/dto/RegisterPeriodDtos.kt
+++ b/src/main/kotlin/com/example/checkcheck/lecture/dto/RegisterPeriodDtos.kt
@@ -3,60 +3,35 @@ package com.example.checkcheck.lecture.dto
 import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Pattern
-import java.time.LocalDate
-import java.time.LocalTime
+import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 data class RegisterPeriodRequestDto(
     val id: Long? = null,
 
-    @field:NotBlank(message = "수강신청 시작일을 입력해주세요.")
+    @field:NotBlank(message = "수강신청 시작 일시를 입력해주세요.")
     @field:Pattern(
-        regexp = "^([0-9]{2})-([0-9]{2})-([0-9]{2})\$",
-        message = "날짜 형식을 확인해주세요! yy-MM-dd"
+        regexp = "^([0-9]{2})-([0-9]{2})-([0-9]{2}) ([0-9]{2}):([0-9]{2})$",
+        message = "형식을 확인해주세요! yy-MM-dd HH:mm"
     )
-    @JsonProperty("registerStartDate")
-    private var registerStartDate: String?,
+    @JsonProperty("registerStartDateTime")
+    val registerStartDateTime: String,
 
-    @field:NotBlank(message = "수강신청 종료일을 입력해주세요.")
+    @field:NotBlank(message = "수강신청 종료 일시를 입력해주세요.")
     @field:Pattern(
-        regexp = "^([0-9]{2})-([0-9]{2})-([0-9]{2})\$",
-        message = "날짜 형식을 확인해주세요! yy-MM-dd"
+        regexp = "^([0-9]{2})-([0-9]{2})-([0-9]{2}) ([0-9]{2}):([0-9]{2})$",
+        message = "형식을 확인해주세요! yy-MM-dd HH:mm"
     )
-    @JsonProperty("registerEndDate")
-    private var registerEndDate: String?,
-
-    @field:NotBlank(message = "수강신청 시작시간을 입력해주세요.")
-    @field:Pattern(
-        regexp = "^([01]\\d|2[0-3]):([0-5]\\d)\$",
-        message = "시간 형식을 확인해주세요! HH:mm"
-    )
-    @JsonProperty("registerStartAt")
-    private var registerStartAt: String?,
-
-    @field:NotBlank(message = "수강신청 종료시간을 입력해주세요.")
-    @field:Pattern(
-        regexp = "^([01]\\d|2[0-3]):([0-5]\\d)\$",
-        message = "시간 형식을 확인해주세요! HH:mm"
-    )
-    @JsonProperty("registerEndAt")
-    private var registerEndAt: String?
+    @JsonProperty("registerEndDateTime")
+    val registerEndDateTime: String
 ) {
-    val registerStartLocalDate: LocalDate
-        get() = registerStartDate!!.toLocalDate()
+    val registerStartLocalDateTime: LocalDateTime
+        get() = registerStartDateTime.toLocalDateTime()
 
-    val registerEndLocalDate: LocalDate
-        get() = registerEndDate!!.toLocalDate()
+    val registerEndLocalDateTime: LocalDateTime
+        get() = registerEndDateTime.toLocalDateTime()
 
-    val registerStartLocalAt: LocalTime
-        get() = registerStartAt!!.toLocalTime()
 
-    val registerEndLocalEndAt: LocalTime
-        get() = registerEndAt!!.toLocalTime()
-
-    private fun String.toLocalDate(): LocalDate =
-        LocalDate.parse(this, DateTimeFormatter.ofPattern("yy-MM-dd"))
-
-    private fun String.toLocalTime(): LocalTime =
-        LocalTime.parse(this, DateTimeFormatter.ofPattern("HH:mm"))
+    private fun String.toLocalDateTime(): LocalDateTime =
+        LocalDateTime.parse(this, DateTimeFormatter.ofPattern("yy-MM-dd HH:mm"))
 }

--- a/src/main/kotlin/com/example/checkcheck/lecture/dto/RegisterPeriodDtos.kt
+++ b/src/main/kotlin/com/example/checkcheck/lecture/dto/RegisterPeriodDtos.kt
@@ -11,7 +11,7 @@ data class RegisterPeriodRequestDto(
 
     @field:NotBlank(message = "수강신청 시작 일정를 입력해주세요.")
     @field:Pattern(
-        regexp = "^([0-9]{2})-([0-9]{2})-([0-9]{2}) ([01]\\d|2[0-3]):([0-5]\\d)\$",
+        regexp = "^([0-9]{2})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]) ([01]\\d|2[0-3]):([0-5]\\d)\$",
         message = "형식을 확인해주세요! yy-MM-dd HH:mm"
     )
     @JsonProperty("registerStartDateTime")
@@ -19,7 +19,7 @@ data class RegisterPeriodRequestDto(
 
     @field:NotBlank(message = "수강신청 종료 일정를 입력해주세요.")
     @field:Pattern(
-        regexp = "^([0-9]{2})-([0-9]{2})-([0-9]{2}) ([01]\\d|2[0-3]):([0-5]\\d)\$",
+        regexp = "^([0-9]{2})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]) ([01]\\d|2[0-3]):([0-5]\\d)\$",
         message = "형식을 확인해주세요! yy-MM-dd HH:mm"
     )
     @JsonProperty("registerEndDateTime")

--- a/src/main/kotlin/com/example/checkcheck/lecture/entity/Lecture.kt
+++ b/src/main/kotlin/com/example/checkcheck/lecture/entity/Lecture.kt
@@ -39,10 +39,8 @@ class Lecture(
 }
 
 fun RegisterPeriod.toDto() = RegisterPeriodDto(
-    registerStartDate = this.registerStartDate,
-    registerEndDate = this.registerEndDate,
-    registerStartAt = this.registerStartAt,
-    registerEndAt = this.registerEndAt
+    registerStartDateTime = this.registerStartDateTime,
+    registerEndDateTime = this.registerEndDateTime,
 )
 
 fun LectureSchedule.toDto() = LectureScheduleDto(

--- a/src/main/kotlin/com/example/checkcheck/lecture/entity/LectureSchedule.kt
+++ b/src/main/kotlin/com/example/checkcheck/lecture/entity/LectureSchedule.kt
@@ -8,7 +8,7 @@ import jakarta.persistence.*
 class LectureSchedule (
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
-    var id: Long? = null,
+    val id: Long? = null,
 
     @Column
     var lectureStartDate: String,

--- a/src/main/kotlin/com/example/checkcheck/lecture/entity/RegisterPeriod.kt
+++ b/src/main/kotlin/com/example/checkcheck/lecture/entity/RegisterPeriod.kt
@@ -1,5 +1,6 @@
 package com.example.checkcheck.lecture.entity
 
+import com.example.checkcheck.lecture.dto.RegisterPeriodRequestDto
 import jakarta.persistence.*
 import java.time.LocalDate
 import java.time.LocalTime
@@ -11,12 +12,18 @@ class RegisterPeriod(
     val id: Long? = null,
 
     @Column
-    val registerStartDateTime: String,
+    var registerStartDateTime: String,
 
     @Column
-    val registerEndDateTime: String,
+    var registerEndDateTime: String,
 
     @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
     @JoinColumn(foreignKey = ForeignKey(name = "fk_register_period_lecture_id"))
     val lecture: Lecture
-)
+) {
+    fun toResponse() = RegisterPeriodRequestDto(
+        id = this.id,
+        registerStartDateTime = this.registerStartDateTime,
+        registerEndDateTime = this.registerEndDateTime
+    )
+}

--- a/src/main/kotlin/com/example/checkcheck/lecture/entity/RegisterPeriod.kt
+++ b/src/main/kotlin/com/example/checkcheck/lecture/entity/RegisterPeriod.kt
@@ -11,16 +11,10 @@ class RegisterPeriod(
     val id: Long? = null,
 
     @Column
-    val registerStartDate: String,
+    val registerStartDateTime: String,
 
     @Column
-    val registerEndDate: String,
-
-    @Column
-    val registerStartAt: String,
-
-    @Column
-    val registerEndAt: String,
+    val registerEndDateTime: String,
 
     @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
     @JoinColumn(foreignKey = ForeignKey(name = "fk_register_period_lecture_id"))

--- a/src/main/kotlin/com/example/checkcheck/lecture/service/LectureService.kt
+++ b/src/main/kotlin/com/example/checkcheck/lecture/service/LectureService.kt
@@ -4,6 +4,7 @@ import com.example.checkcheck.common.exceptions.lecture.LectureException
 import com.example.checkcheck.lecture.dto.LectureRequestDto
 import com.example.checkcheck.lecture.dto.LectureResponseDto
 import com.example.checkcheck.lecture.dto.LectureScheduleRequestDto
+import com.example.checkcheck.lecture.dto.RegisterPeriodRequestDto
 import com.example.checkcheck.lecture.entity.Lecture
 import com.example.checkcheck.lecture.entity.LectureSchedule
 import com.example.checkcheck.lecture.entity.RegisterPeriod
@@ -181,5 +182,33 @@ class LectureService (
     // 강의 삭제
     fun deleteLectures(id: Long) {
         lectureRepository.deleteById(id)
+    }
+
+    // 수강신청 시작 변경
+    fun putRegisterStartDateTime(registerPeriodRequestDto: RegisterPeriodRequestDto, id: Long): RegisterPeriodRequestDto {
+        val registerPeriod = registerPeriodRepository.findByIdOrNull(id)
+            ?: throw LectureException("존재하지 않는 수강신청 기간입니다.")
+
+        if (registerPeriodRequestDto.registerStartLocalDateTime.isAfter(registerPeriodRequestDto.registerEndLocalDateTime)) {
+            throw LectureException("수강신청 시작일은 종료일보다 늦을 수 없습니다.")
+        }
+
+        registerPeriod.registerStartDateTime = registerPeriodRequestDto.registerStartDateTime
+        val updatedPeriod = registerPeriodRepository.save(registerPeriod)
+        return updatedPeriod.toResponse()
+    }
+
+    // 수강신청 종료 변경
+    fun putRegisterEndDateTime(registerPeriodRequestDto: RegisterPeriodRequestDto, id: Long): RegisterPeriodRequestDto {
+        val registerPeriod = registerPeriodRepository.findByIdOrNull(id)
+            ?: throw LectureException("존재하지 않는 수강신청 기간입니다.")
+
+        if (registerPeriodRequestDto.registerEndLocalDateTime.isBefore(registerPeriodRequestDto.registerStartLocalDateTime)) {
+            throw LectureException("수강신청 종료일은 시작일보다 빠를 수 없습니다.")
+        }
+
+        registerPeriod.registerEndDateTime = registerPeriodRequestDto.registerEndDateTime
+        val updatedPeriod = registerPeriodRepository.save(registerPeriod)
+        return updatedPeriod.toResponse()
     }
 }

--- a/src/main/kotlin/com/example/checkcheck/lecture/service/LectureService.kt
+++ b/src/main/kotlin/com/example/checkcheck/lecture/service/LectureService.kt
@@ -33,10 +33,13 @@ class LectureService (
     // 강의 개설
     fun postLectures(lectureRequestDto: LectureRequestDto, memberId: Long): String {
         val existingLecture = lectureRepository.findByTitle(lectureRequestDto.title)
+
+        // 강의명 중복 검사
         if (existingLecture != null) {
             throw RuntimeException("이미 존재하는 강의이름입니다!")
         }
 
+        // 사용자 유효성 검사
         val member = memberRepository.findByIdOrNull(memberId)
             ?: throw RuntimeException("존재하지 않는 사용자입니다!")
 
@@ -46,6 +49,7 @@ class LectureService (
             member = member
         )
 
+        // 강의 등록
         lectureRepository.save(lecture)
 
         val registerPeriod = RegisterPeriod(
@@ -57,6 +61,7 @@ class LectureService (
             lecture = lecture
         )
 
+        // 수강신청 기간 등록
         registerPeriodRepository.save(registerPeriod)
 
         val lectureSchedule = LectureSchedule(
@@ -71,6 +76,7 @@ class LectureService (
             lecture = lecture
         )
 
+        // 강의 시간표 등록
         lectureScheduleRepository.save(lectureSchedule)
         return "강의가 등록되었습니다!"
     }
@@ -87,7 +93,7 @@ class LectureService (
         return lectures.map { it.toResponse() }
     }
 
-    // 강의 시간표 요일 변경
+    // 강의 요일 변경
     fun putLectureWeekDay(lectureScheduleRequestDto: LectureScheduleRequestDto, id: Long): LectureScheduleRequestDto {
         val lectureSchedule = lectureScheduleRepository.findByIdOrNull(id)
             ?: throw LectureException("존재하지 않는 강의 시간표입니다.")
@@ -111,6 +117,7 @@ class LectureService (
         return updatedSchedule.toResponse()
     }
 
+
     // 강의 종료시간 변경
     fun putLectureEndAt(lectureScheduleRequestDto: LectureScheduleRequestDto, id: Long): LectureScheduleRequestDto {
         val lectureSchedule = lectureScheduleRepository.findByIdOrNull(id)
@@ -121,6 +128,54 @@ class LectureService (
         }
 
         lectureSchedule.lectureEndAt = lectureScheduleRequestDto.lectureEndAt
+        val updatedSchedule = lectureScheduleRepository.save(lectureSchedule)
+        return updatedSchedule.toResponse()
+    }
+
+    // 강의 시작기간 변경
+    fun putLectureStartDate(lectureScheduleRequestDto: LectureScheduleRequestDto, id: Long): LectureScheduleRequestDto {
+        val lectureSchedule = lectureScheduleRepository.findByIdOrNull(id)
+            ?: throw LectureException("존재하지 않는 강의 시간표입니다.")
+
+        if (lectureScheduleRequestDto.lectureStartLocalDate.isAfter(lectureScheduleRequestDto.lectureEndLocalDate)) {
+            throw LectureException("강의 시작일은 종료일보다 늦을 수 없습니다.")
+        }
+
+        lectureSchedule.lectureStartDate = lectureScheduleRequestDto.lectureStartDate
+        val updatedSchedule = lectureScheduleRepository.save(lectureSchedule)
+        return updatedSchedule.toResponse()
+    }
+
+    // 강의 종료기간 변경
+    fun putLectureEndDate(lectureScheduleRequestDto: LectureScheduleRequestDto, id: Long): LectureScheduleRequestDto {
+        val lectureSchedule = lectureScheduleRepository.findByIdOrNull(id)
+            ?: throw LectureException("존재하지 않는 강의 시간표입니다.")
+
+        if (lectureScheduleRequestDto.lectureEndLocalDate.isBefore(lectureScheduleRequestDto.lectureStartLocalDate)) {
+            throw LectureException("강의 종료일은 시작일보다 빠를 수 없습니다.")
+        }
+
+        lectureSchedule.lectureEndDate = lectureScheduleRequestDto.lectureEndDate
+        val updatedSchedule = lectureScheduleRepository.save(lectureSchedule)
+        return updatedSchedule.toResponse()
+    }
+
+    // 강의실 변경
+    fun putLecturePlace(lectureScheduleRequestDto: LectureScheduleRequestDto, id: Long): LectureScheduleRequestDto {
+        val lectureSchedule = lectureScheduleRepository.findByIdOrNull(id)
+            ?: throw LectureException("존재하지 않는 강의 시간표입니다.")
+
+        lectureSchedule.lecturePlace = lectureScheduleRequestDto.lecturePlace
+        val updatedSchedule = lectureScheduleRepository.save(lectureSchedule)
+        return updatedSchedule.toResponse()
+    }
+
+    // 강의 정보 변경
+    fun putLectureInfo(lectureScheduleRequestDto: LectureScheduleRequestDto, id: Long): LectureScheduleRequestDto {
+        val lectureSchedule = lectureScheduleRepository.findByIdOrNull(id)
+            ?: throw LectureException("존재하지 않는 강의 시간표입니다.")
+
+        lectureSchedule.lectureInfo = lectureScheduleRequestDto.lectureInfo
         val updatedSchedule = lectureScheduleRepository.save(lectureSchedule)
         return updatedSchedule.toResponse()
     }

--- a/src/main/kotlin/com/example/checkcheck/lecture/service/LectureService.kt
+++ b/src/main/kotlin/com/example/checkcheck/lecture/service/LectureService.kt
@@ -54,10 +54,8 @@ class LectureService (
 
         val registerPeriod = RegisterPeriod(
             id = null,
-            registerStartDate = lectureRequestDto.registerStartDate,
-            registerEndDate = lectureRequestDto.registerEndDate,
-            registerStartAt = lectureRequestDto.registerStartAt,
-            registerEndAt = lectureRequestDto.registerEndAt,
+            registerStartDateTime = lectureRequestDto.registerStartDateTime,
+            registerEndDateTime = lectureRequestDto.registerEndDateTime,
             lecture = lecture
         )
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,9 +4,12 @@ spring:
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: "jdbc:mysql://mysql-container:3306/checkcheck_db?autoReconnect=true&useUnicode=true&serverTimezone=Asia/Seoul"
-    username: checkcheck_admin
-    password: checkcheck
+    url: "jdbc:mysql://localhost:3306/checkcheck?autoReconnect=true&useUnicode=true&serverTimezone=Asia/Seoul"
+    username: KJW
+    password: KJW
+#    url: "jdbc:mysql://mysql-container:3306/checkcheck_db?autoReconnect=true&useUnicode=true&serverTimezone=Asia/Seoul"
+#    username: checkcheck_admin
+#    password: checkcheck
 
   jpa:
     database: mysql

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,13 +3,9 @@ spring:
     name: checkcheck
 
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: "jdbc:mysql://localhost:3306/checkcheck?autoReconnect=true&useUnicode=true&serverTimezone=Asia/Seoul"
-    username: KJW
-    password: KJW
-#    url: "jdbc:mysql://mysql-container:3306/checkcheck_db?autoReconnect=true&useUnicode=true&serverTimezone=Asia/Seoul"
-#    username: checkcheck_admin
-#    password: checkcheck
+    url: "jdbc:mysql://mysql-container:3306/checkcheck_db?autoReconnect=true&useUnicode=true&serverTimezone=Asia/Seoul"
+    username: checkcheck_admin
+    password: checkcheck
 
   jpa:
     database: mysql

--- a/src/test/kotlin/com/example/checkcheck/lecture/controller/LectureControllerTest.kt
+++ b/src/test/kotlin/com/example/checkcheck/lecture/controller/LectureControllerTest.kt
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.data.web.JsonPath
 import org.springframework.http.MediaType
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.authority.SimpleGrantedAuthority
@@ -37,7 +36,7 @@ class LectureControllerTest {
         val customUser = CustomUser(
             email = "test@test.com",
             password = "testtest1@",
-            authority = listOf( SimpleGrantedAuthority("ROLE_MEMBER") ),
+            authority = listOf(SimpleGrantedAuthority("ROLE_MEMBER")),
             id = 1L
         )
 
@@ -70,19 +69,15 @@ class LectureControllerTest {
                 "lectureEndAt": "10:00",
                 "lectureWeekDay": "MON",
                 "lecturePlace": "Test Room",
-                "registerStartDate": "21-07-01",
-                "registerEndDate": "21-07-30",
-                "registerStartAt": "09:00",
-                "registerEndAt": "10:00",
+                "registerStartDateTime": "21-02-01 10:00",
+                "registerEndDateTime": "21-02-25 10:00",
                 "lectureInfo": "Test Lecture Information"
             }
             """.trimIndent()
                 )
                 .contentType(MediaType.APPLICATION_JSON)
         )
-            .andExpect(
-                status().isCreated
-            )
+            .andExpect(status().isCreated)
 
         verify(exactly = 1) { lectureService.postLectures(any(), 1L) }
     }
@@ -93,7 +88,8 @@ class LectureControllerTest {
 
         mockMvc.perform(
             MockMvcRequestBuilders.post("/api/lecture/open")
-                .content("""
+                .content(
+                    """
             {
                 "title": "testLecture",
                 "lectureStartDate": "21-07-03",
@@ -102,13 +98,12 @@ class LectureControllerTest {
                 "lectureEndAt": "10:00",
                 "lectureWeekDay": "MON",
                 "lecturePlace": "Test Room",
-                "registerStartDate": "21-07-01",
-                "registerEndDate": "21-07-30",
-                "registerStartAt": "09:00",
-                "registerEndAt": "10:00",
+                "registerStartDateTime": "21-02-01 10:00",
+                "registerEndDateTime": "21-02-25 10:00",
                 "lectureInfo": "Test Lecture Information"
             }
-            """.trimIndent())
+            """.trimIndent()
+                )
                 .contentType(MediaType.APPLICATION_JSON)
         )
             .andExpect(status().isCreated)
@@ -127,12 +122,10 @@ class LectureControllerTest {
         "lectureEndDate": "21-07-30",
         "lectureStartAt": "0900",
         "lectureEndAt": "10:00",
-        "lectureWeekDay": "MN",
+        "lectureWeekDay": "MON",
         "lecturePlace": "Test Room",
-        "registerStartDate": "21-07-01",
-        "registerEndDate": "21-07-30",
-        "registerStartAt": "09:00",
-        "registerEndAt": "10:00",
+        "registerStartDateTime": "21-02-01 10:00",
+        "registerEndDateTime": "21-02-25 10:00",
         "lectureInfo": "Test Lecture Information"
     }
     """.trimIndent()

--- a/src/test/kotlin/com/example/checkcheck/lecture/repository/LectureRepositoryTest.kt
+++ b/src/test/kotlin/com/example/checkcheck/lecture/repository/LectureRepositoryTest.kt
@@ -79,10 +79,8 @@ class LectureRepositoryTest @Autowired constructor(
 
         val registerPeriod = RegisterPeriod(
             id = null,
-            registerStartDate = "23-02-01",
-            registerEndDate = "24-02-25",
-            registerStartAt = "10:00",
-            registerEndAt = "11:00",
+            registerStartDateTime = "23-02-01 10:00",
+            registerEndDateTime = "24-02-25 10:00",
             lecture = l
         )
 

--- a/src/test/kotlin/com/example/checkcheck/lecture/repository/RegisterPeriodRepositoryTest.kt
+++ b/src/test/kotlin/com/example/checkcheck/lecture/repository/RegisterPeriodRepositoryTest.kt
@@ -45,10 +45,8 @@ class RegisterPeriodRepositoryTest @Autowired constructor(
 
         val registerPeriod = RegisterPeriod(
             id = null,
-            registerStartDate = "23-02-01",
-            registerEndDate = "24-02-25",
-            registerStartAt = "10:00",
-            registerEndAt = "11:00",
+            registerStartDateTime = "23-02-01 10:00",
+            registerEndDateTime = "24-02-25 10:00",
             lecture = lecture
         )
 

--- a/src/test/kotlin/com/example/checkcheck/lecture/service/LectureServiceTest.kt
+++ b/src/test/kotlin/com/example/checkcheck/lecture/service/LectureServiceTest.kt
@@ -51,10 +51,8 @@ class LectureServiceTest {
             _lectureWeekDay = WeekDay.MON,
             _lecturePlace = "Test Room",
             _lectureInfo = "Test Lecture Information",
-            _registerStartDate = "23-02-01",
-            _registerEndDate = "24-02-25",
-            _registerStartAt = "10:00",
-            _registerEndAt = "11:00",
+            _registerStartDateTime = "23-02-01 10:00",
+            _registerEndDateTime = "24-02-25 10:00",
         )
 
         val testLecture = Lecture(
@@ -75,10 +73,8 @@ class LectureServiceTest {
         )
         val testRegisterPeriod = RegisterPeriod(
             id = null,
-            registerStartDate = "23-02-01",
-            registerEndDate = "24-02-25",
-            registerStartAt = "10:00",
-            registerEndAt = "11:00",
+            registerStartDateTime = "23-02-01 10:00",
+            registerEndDateTime = "24-02-25 10:00",
             lecture = testLecture
         )
         every { memberRepository.findByIdOrNull(1) } returns member


### PR DESCRIPTION
일부 Api 주소 변경
- 직관적으로 알아볼 수 있게 일부 Api 주소를 변경하였습니다.
- startat -> lectureStartAt / endat -> lectureEndAt 등

강의 시작 및 종료 기간 Api 추가
- 기존 강의 시간만 있었던 것을 기간도 추가하였습니다.
- 강의 종료일이 시작일보다 빠르게, 강의 시작일이 강의 종료일보다 느리게 설정하지 못하게 예외처리 추가

수강신청 시작 및 종료 일정 Api 추가
- 추가하면서 일정 및 시간을 한번에 받을 수 있게 LocalDateTime yy-MM-dd HH:mm 형식으로 변경하였습니다.
- 이에 따라 테스트 코드도 형식에 맞게 수정하였습니다.

날짜 정규 표현식 변경
- 기존에는 월과 일이 99까지 표현할 수 있었습니다.
- 월은 12월 / 일은 31일까지로 변경하였습니다.