### PR TITLE
사용자 강의 개설 조건 추가

### DIFF
--- a/src/main/kotlin/com/example/checkcheck/lecture/entity/Lecture.kt
+++ b/src/main/kotlin/com/example/checkcheck/lecture/entity/Lecture.kt
@@ -8,6 +8,9 @@ import jakarta.persistence.*
 import com.example.checkcheck.member.entity.Member
 
 @Entity
+@Table(
+    uniqueConstraints = [UniqueConstraint(name = "uk_lecture_title", columnNames = ["title"])]
+)
 class Lecture(
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
@@ -17,7 +20,7 @@ class Lecture(
     var title: String,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(foreignKey = ForeignKey(name = "fk_lecture_member_id"))
+    @JoinColumn(foreignKey = ForeignKey(name = "fk_lecture_id_member_id"))
     var member: Member
 ) {
 

--- a/src/main/kotlin/com/example/checkcheck/lecture/entity/Lecture.kt
+++ b/src/main/kotlin/com/example/checkcheck/lecture/entity/Lecture.kt
@@ -8,9 +8,6 @@ import jakarta.persistence.*
 import com.example.checkcheck.member.entity.Member
 
 @Entity
-@Table(
-    uniqueConstraints = [UniqueConstraint(name = "uk_lecture_title", columnNames = ["title"])]
-)
 class Lecture(
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
@@ -19,8 +16,8 @@ class Lecture(
     @Column(nullable = false, updatable = false, length = 50)
     var title: String,
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(foreignKey = ForeignKey(name = "fk_lecture_id_member_id"))
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(foreignKey = ForeignKey(name = "fk_lecture_member_id"))
     var member: Member
 ) {
 

--- a/src/main/kotlin/com/example/checkcheck/lecture/repository/LectureRepository.kt
+++ b/src/main/kotlin/com/example/checkcheck/lecture/repository/LectureRepository.kt
@@ -17,4 +17,6 @@ interface LectureRepository : JpaRepository<Lecture, Long> {
     fun findAllByFetchJoin() : List<Lecture>
 
     fun findByMember(member: Member): List<Lecture>
+
+    fun countByMember(member: Member): Long
 }

--- a/src/main/kotlin/com/example/checkcheck/lecture/service/LectureService.kt
+++ b/src/main/kotlin/com/example/checkcheck/lecture/service/LectureService.kt
@@ -33,16 +33,22 @@ class LectureService (
 
     // 강의 개설
     fun postLectures(lectureRequestDto: LectureRequestDto, memberId: Long): String {
-        val existingLecture = lectureRepository.findByTitle(lectureRequestDto.title)
-
-        // 강의명 중복 검사
-        if (existingLecture != null) {
-            throw RuntimeException("이미 존재하는 강의이름입니다!")
-        }
 
         // 사용자 유효성 검사
         val member = memberRepository.findByIdOrNull(memberId)
             ?: throw RuntimeException("존재하지 않는 사용자입니다!")
+
+        // 강의명 중복 검사
+        val existingLecture = lectureRepository.findByTitle(lectureRequestDto.title)
+        if (existingLecture != null) {
+            throw RuntimeException("이미 존재하는 강의이름입니다!")
+        }
+
+        // 사용자가 생성한 강의 수 확인
+        val existingLecturesCount = lectureRepository.countByMember(member)
+        if (existingLecturesCount >= 4) {
+            throw RuntimeException("한 사용자는 최대 4개의 강의만 생성할 수 있습니다.")
+        }
 
         val lecture = Lecture(
             id = null,

--- a/src/test/kotlin/com/example/checkcheck/lecture/controller/LectureControllerTest.kt
+++ b/src/test/kotlin/com/example/checkcheck/lecture/controller/LectureControllerTest.kt
@@ -140,5 +140,5 @@ class LectureControllerTest {
 
         verify(exactly = 0) { lectureService.postLectures(any(), 1L) }
     }
-
+    
 }

--- a/src/test/kotlin/com/example/checkcheck/lecture/service/LectureServiceTest.kt
+++ b/src/test/kotlin/com/example/checkcheck/lecture/service/LectureServiceTest.kt
@@ -15,20 +15,19 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Test
 import org.springframework.data.repository.findByIdOrNull
-import java.time.LocalDateTime
 import kotlin.test.assertEquals
 
 class LectureServiceTest {
-    private val memberRepository : MemberRepository = mockk()
-    private val lectureRepository : LectureRepository = mockk()
-    private val registerPeriodRepository : RegisterPeriodRepository = mockk()
-    private val lectureScheduleRepository : LectureScheduleRepository = mockk()
-    private val lectureService : LectureService
-    = LectureService(
+    private val memberRepository: MemberRepository = mockk()
+    private val lectureRepository: LectureRepository = mockk()
+    private val registerPeriodRepository: RegisterPeriodRepository = mockk()
+    private val lectureScheduleRepository: LectureScheduleRepository = mockk()
+    private val lectureService: LectureService = LectureService(
         memberRepository = memberRepository,
         lectureRepository = lectureRepository,
         registerPeriodRepository = registerPeriodRepository,
-        lectureScheduleRepository = lectureScheduleRepository,)
+        lectureScheduleRepository = lectureScheduleRepository,
+    )
 
     @Test
     fun `강의 생성 테스트`() {
@@ -80,6 +79,7 @@ class LectureServiceTest {
         every { memberRepository.findByIdOrNull(1) } returns member
         every { lectureRepository.save(any()) } returns testLecture
         every { lectureRepository.findByTitle(testLectureRequestDto.title) } returns null
+        every { lectureRepository.countByMember(member) } returns 0
         every { registerPeriodRepository.save(any()) } returns testRegisterPeriod
         every { lectureScheduleRepository.save(any()) } returns testLectureSchedule
 
@@ -93,6 +93,7 @@ class LectureServiceTest {
 
         assertEquals(result, "강의가 등록되었습니다!")
     }
+
 
     @Test
     fun `강의 조회 테스트`() {

--- a/src/test/kotlin/com/example/checkcheck/lecture/service/LectureServiceTest.kt
+++ b/src/test/kotlin/com/example/checkcheck/lecture/service/LectureServiceTest.kt
@@ -14,15 +14,16 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.data.repository.findByIdOrNull
 import kotlin.test.assertEquals
 
 class LectureServiceTest {
-    private val memberRepository: MemberRepository = mockk()
-    private val lectureRepository: LectureRepository = mockk()
-    private val registerPeriodRepository: RegisterPeriodRepository = mockk()
-    private val lectureScheduleRepository: LectureScheduleRepository = mockk()
-    private val lectureService: LectureService = LectureService(
+    private val memberRepository : MemberRepository = mockk()
+    private val lectureRepository : LectureRepository = mockk()
+    private val registerPeriodRepository : RegisterPeriodRepository = mockk()
+    private val lectureScheduleRepository : LectureScheduleRepository = mockk()
+    private val lectureService : LectureService = LectureService(
         memberRepository = memberRepository,
         lectureRepository = lectureRepository,
         registerPeriodRepository = registerPeriodRepository,
@@ -41,7 +42,7 @@ class LectureServiceTest {
             name = testName
         )
 
-        val testLectureRequestDto : LectureRequestDto = LectureRequestDto(
+        val testLectureRequestDto = LectureRequestDto(
             _title = "test",
             _lectureStartDate = "23-07-01",
             _lectureEndDate = "23-07-30",
@@ -76,6 +77,7 @@ class LectureServiceTest {
             registerEndDateTime = "24-02-25 10:00",
             lecture = testLecture
         )
+
         every { memberRepository.findByIdOrNull(1) } returns member
         every { lectureRepository.save(any()) } returns testLecture
         every { lectureRepository.findByTitle(testLectureRequestDto.title) } returns null
@@ -94,6 +96,82 @@ class LectureServiceTest {
         assertEquals(result, "강의가 등록되었습니다!")
     }
 
+    @Test
+    fun `강의 개설 수 제한 테스트`() {
+        val testEmail = "test@test.com"
+        val testPassword = "testtest1@"
+        val testName = "test"
+        val member = Member(
+            id = 1,
+            email = testEmail,
+            password = testPassword,
+            name = testName
+        )
+
+        val testLectureRequestDto = LectureRequestDto(
+            _title = "test",
+            _lectureStartDate = "23-07-01",
+            _lectureEndDate = "23-07-30",
+            _lectureStartAt = "09:00",
+            _lectureEndAt = "10:00",
+            _lectureWeekDay = WeekDay.MON,
+            _lecturePlace = "Test Room",
+            _lectureInfo = "Test Lecture Information",
+            _registerStartDateTime = "23-02-01 10:00",
+            _registerEndDateTime = "24-02-25 10:00",
+        )
+
+        every { memberRepository.findByIdOrNull(1) } returns member
+        every { lectureRepository.findByTitle(testLectureRequestDto.title) } returns null
+        every { lectureRepository.countByMember(member) } returns 4
+
+        val exception = assertThrows<RuntimeException> {
+            lectureService.postLectures(testLectureRequestDto, 1)
+        }
+
+        assertEquals("한 사용자는 최대 4개의 강의만 생성할 수 있습니다.", exception.message)
+    }
+
+    @Test
+    fun `강의명 중복 검사 테스트`() {
+        val testEmail = "test@test.com"
+        val testPassword = "testtest1@"
+        val testName = "test"
+        val member = Member(
+            id = 1,
+            email = testEmail,
+            password = testPassword,
+            name = testName
+        )
+
+        val testLectureRequestDto = LectureRequestDto(
+            _title = "test",
+            _lectureStartDate = "23-07-01",
+            _lectureEndDate = "23-07-30",
+            _lectureStartAt = "09:00",
+            _lectureEndAt = "10:00",
+            _lectureWeekDay = WeekDay.MON,
+            _lecturePlace = "Test Room",
+            _lectureInfo = "Test Lecture Information",
+            _registerStartDateTime = "23-02-01 10:00",
+            _registerEndDateTime = "24-02-25 10:00",
+        )
+
+        val existingLecture = Lecture(
+            id = 1,
+            title = "test",
+            member = member
+        )
+
+        every { memberRepository.findByIdOrNull(1) } returns member
+        every { lectureRepository.findByTitle(testLectureRequestDto.title) } returns existingLecture
+
+        val exception = assertThrows<RuntimeException> {
+            lectureService.postLectures(testLectureRequestDto, 1)
+        }
+
+        assertEquals("이미 존재하는 강의이름입니다!", exception.message)
+    }
 
     @Test
     fun `강의 조회 테스트`() {


### PR DESCRIPTION
[코드 개선 내용]

[오류 사항]
Postman 강의개설 테스트에서 오류가 발생했습니다.
한 명의 사용자에게 한 개의 강의만 생성할 수 있게 설정되어있었습니다.
최대 4개까지의 강의를 생성할 수 있게 코드 및 맵핑을 수정하였습니다.

[해결 방안]
- @OneToOne(fetch = FetchType.LAZY) -> @ManyToOne(fetch = FetchType.LAZY)
- 사용자가 생성한 강의 수 확인하는 Service 코드 추가
- 이에 대한 강의 개설 수 및 강의명 중복 테스트 코드 추가
